### PR TITLE
Allow for modification of Git Branch and Nginx HTTP Ports

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -4,6 +4,9 @@ app_package: flaskapp
 app_callable: app
 base_dir: '/srv/{{ app_name }}'
 nginx_server_name: 'localhost {{ app_name }}.local'
+# This affects HTTP only. HTTPS requires manual config.
+# Most people want to use 80 here.
+nginx_http_port: 80
 uwsgi_module: '{{ app_package }}:{{ app_callable }}'
 uwsgi_processes: 1
 uwsgi_threads: 1

--- a/group_vars/all
+++ b/group_vars/all
@@ -12,6 +12,7 @@ uwsgi_env: []
 # uwsgi_env:
 # - 'DJANGO_SETTINGS_MODULE={{ app_package }}.settings'
 git_repo: https://github.com/Kwpolska/flask-demo-app
+git_branch: master
 # If this is set to "yes", the global nginx config will be replaced by one
 # that has no default hosts. This is based on the default config of your OS.
 # You should not use it if you customized /etc/nginx/nginx.conf in any way,

--- a/roles/configure_nginx_uwsgi/templates/nginx-host.conf.j2
+++ b/roles/configure_nginx_uwsgi/templates/nginx-host.conf.j2
@@ -1,6 +1,6 @@
 server {
     # for a public HTTP server:
-    listen 80;
+    listen {{nginx_http_port}};
     # for a public HTTPS server:
     # listen 443 ssl;
     # SSL requires extra configuration!

--- a/roles/setup_venv_app/tasks/main.yml
+++ b/roles/setup_venv_app/tasks/main.yml
@@ -8,7 +8,10 @@
   command: "{{ virtualenv_cmd }} '{{ base_dir }}'"
 
 - name: Clone Git repository
-  command: "git clone {{ git_repo }} '{{ base_dir }}/appdata'"
+  git:
+    repo: '{{ git_repo }}'
+    dest: '{{ base_dir }}/appdata'
+    version: '{{ git_branch }}'
 
 - name: Install requirements.txt
   command: "'{{ base_dir }}/bin/pip' install -r '{{ base_dir }}/appdata/requirements.txt'"


### PR DESCRIPTION
Awesome stuff!
These are some modifications I made to make it easier for me to run the playbook. I think it'll help someone else too.

- Allows`git_branch` to be set in  `group_vars/all`. The set branch is checked out after cloning the repository.

- Allows `nginx_http_port` and `nginx_https_port` to be set in `group_vars/all` to modify the port Nginx should run on. This only works if `nginx_hostless_global_config` is set to `yes` in `group_vars/all`.

Cheers