### PR TITLE
do not fail if SElinux is completely disabled

### DIFF
--- a/roles/cleanup_selinux_CentOS_Fedora/tasks/main.yml
+++ b/roles/cleanup_selinux_CentOS_Fedora/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remember SELinux status
-  set_fact: "selinux_prev={{ ansible_selinux['mode'] }}"
+  set_fact: "selinux_prev={{ ansible_selinux['mode'] | default('disabled') }}"
 
 - name: Temporarily disable SELinux
   selinux:

--- a/roles/selinux_policy_CentOS_Fedora/tasks/main.yml
+++ b/roles/selinux_policy_CentOS_Fedora/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - name: Make static files readable by nginx (SELinux)
   command: chcon -R system_u:system_r:httpd_t:s0 '{{ appdata_dir }}/static'
+  when: selinux_prev != 'disabled'
 
 - name: Re-enable SELinux
   selinux:
@@ -24,6 +25,7 @@
 
 - name: Import SELinux policy
   command: semodule -i /tmp/nginx-uwsgi.pp
+  when: selinux_prev != 'disabled'
 
 - name: Delete SELinux policy file
   file:


### PR DESCRIPTION
in the case that SElinux is completely turned off (not just permissive) some tasks might fail.
added a fix to handle this gracefully.

```
# ansible localhost -m setup |grep -A2 ansible_selinux
        "ansible_selinux": {
            "status": "disabled"
        }, 
```